### PR TITLE
fix: Remove trailing character from blog post link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repository aims to organize resources focused on helping people (including 
 
 ## Tutorials, guides and educational blog posts
 
-- [Synthetic data: save money, time and carbon with open source](https://huggingface.co/blog/synthetic-data-save-costs): shows how to use an open-source LLM to create synthetic data to train your customized model in a few steps.=
+- [Synthetic data: save money, time and carbon with open source](https://huggingface.co/blog/synthetic-data-save-costs): shows how to use an open-source LLM to create synthetic data to train your customized model in a few steps.
 - [Generating a dataset of queries for training and fine-tuning ColPali models on a UFO dataset
 ](https://danielvanstrien.xyz/posts/post-with-code/colpali/2024-09-23-generate_colpali_dataset.html): using a VLM to generate synthetic data for fine-tuning ColPali models. 
 


### PR DESCRIPTION
## Summary
- Removes accidental trailing `=` character from the synthetic data blog post link

## Test plan
- [x] Verify the link renders correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)