### PR TITLE
add: NVIDIA NeMo Data Designer to libraries section

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This is a very flexible library that is actively being developed and improved. I
 
 > NeMo Data Designer is a Python library for generating high-quality synthetic datasets.
 
-A production-focused library from NVIDIA for creating diverse, realistic synthetic data. Key features include dependency-aware generation (for correlated fields), built-in validation with Python/SQL validators, LLM-as-a-judge quality scoring, and multi-provider support (NVIDIA, OpenAI). Used to prepare pre and post training datasets for NVIDIA Nemotron models.
+A production-focused library from NVIDIA for creating diverse, realistic synthetic data. Key features include dependency-aware generation (for correlated fields), built-in validation with Python/SQL validators, LLM-as-a-judge quality scoring, and multi-provider support (NVIDIA, OpenAI, [Hugging Face](https://huggingface.co/docs/inference-providers/integrations/datadesigner)). Used to prepare pre and post training datasets for NVIDIA Nemotron models.
 
 #### [Torque](https://usetorque.dev)
 An open-source Typescript library for declarative and typesafe synthetic dataset generation. It allows to compose reusable conversations with a declarative DSL and generate production-ready datasets like you build UIs.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ This list isn't compressive and tries to focus on either actively developed libr
 
 This is a very flexible library that is actively being developed and improved. It supports a large number of LLM providers. It includes many common synthetic data generation techniques from papers such as [Self-Instruct](https://distilabel.argilla.io/latest/reference/distilabel/steps/tasks/self_instruct/) and [EvolInstruct](https://distilabel.argilla.io/latest/api/steps/tasks/text_generation/#distilabel.steps.tasks.evol_instruct.base.EvolInstruct).
 
+#### [NeMo Data Designer](https://github.com/NVIDIA-NeMo/DataDesigner)
+
+> NeMo Data Designer is a Python library for generating high-quality synthetic datasets.
+
+A production-focused library from NVIDIA for creating diverse, realistic synthetic data. Key features include dependency-aware generation (for correlated fields), built-in validation with Python/SQL validators, LLM-as-a-judge quality scoring, and multi-provider support (NVIDIA, OpenAI). Used to prepare pre and post training datasets for NVIDIA Nemotron models.
+
 #### [Torque](https://usetorque.dev)
 An open-source Typescript library for declarative and typesafe synthetic dataset generation. It allows to compose reusable conversations with a declarative DSL and generate production-ready datasets like you build UIs.
 


### PR DESCRIPTION
## Summary
- Adds [NeMo Data Designer](https://github.com/NVIDIA-NeMo/DataDesigner) to the Libraries section
- A production-focused Python library from NVIDIA for generating high-quality synthetic datasets
- Key features: dependency-aware generation, built-in validators, LLM-as-a-judge scoring
- Used to prepare datasets for NVIDIA Nemotron models

## Test plan
- [x] Verify link works
- [x] Description follows existing format

🤖 Generated with [Claude Code](https://claude.com/claude-code)